### PR TITLE
Some small changes/improvements

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ All applications have the same API with the following endpoints:
 | Method | Endpoint | Request Body | Response |
 | --- | --- | --- | --- |
 | GET | /footballers[?position=\<position\>] | | Footballer[] |  
-| GET | /foorballers/{id} | | Footballer |  
+| GET | /footballers/{id} | | Footballer |  
 | POST | /footballers |Footballer | Footballer |  
 | DELETE | /footballers/{id} | |
 

--- a/rocket/Cargo.lock
+++ b/rocket/Cargo.lock
@@ -65,6 +65,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +323,7 @@ dependencies = [
 name = "footballmanager"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "diesel",
  "diesel_migrations",
  "dotenv",

--- a/rocket/Cargo.toml
+++ b/rocket/Cargo.toml
@@ -26,6 +26,7 @@ env_logger = "0.7.1"
 
 serde = {version = "1.0.110", features = ["derive"] }
 serde_json = "1.0.53"
+anyhow = "1.0.31"
 
 [dependencies.rocket_contrib]
 version = "0.4.5"

--- a/rocket/rustfmt.toml
+++ b/rocket/rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2018"
+merge_imports = true

--- a/rocket/src/api.rs
+++ b/rocket/src/api.rs
@@ -8,7 +8,7 @@ use crate::{
     PgDatabase,
 };
 use diesel::result::Error;
-use rocket::response::content;
+use rocket::{delete, get, post, response::content};
 
 #[get("/footballers?<position>")]
 pub fn footballers_search(

--- a/rocket/src/api.rs
+++ b/rocket/src/api.rs
@@ -21,7 +21,7 @@ pub fn footballers_search(
     };
     match footballers {
         Ok(footballers) => Ok(content::Json(Json(footballers))),
-        Err(e) => Err(e.into()),
+        Err(e) => Err(e),
     }
 }
 
@@ -32,7 +32,7 @@ pub fn footballer_get(
 ) -> Result<content::Json<Json<Footballer>>, Error> {
     match connection.0.find_by_id(id) {
         Ok(footballer) => Ok(content::Json(Json(footballer))),
-        Err(e) => Err(e.into()),
+        Err(e) => Err(e),
     }
 }
 
@@ -43,7 +43,7 @@ pub fn footballer_create(
 ) -> Result<content::Json<Json<Footballer>>, Error> {
     match connection.0.create(&footballer.0) {
         Ok(footballer) => Ok(content::Json(Json(footballer))),
-        Err(e) => Err(e.into()),
+        Err(e) => Err(e),
     }
 }
 

--- a/rocket/src/api.rs
+++ b/rocket/src/api.rs
@@ -2,9 +2,11 @@ use rocket_contrib::json::Json;
 
 use rocket::http::Status;
 
-use crate::footballer::{Footballer, NewFootballer};
-use crate::footballer_repository::FootballerRepository;
-use crate::PgDatabase;
+use crate::{
+    footballer::{Footballer, NewFootballer},
+    footballer_repository::FootballerRepository,
+    PgDatabase,
+};
 use diesel::result::Error;
 use rocket::response::content;
 

--- a/rocket/src/footballer.rs
+++ b/rocket/src/footballer.rs
@@ -1,5 +1,4 @@
-use serde::Deserialize;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Queryable)]
 pub struct Footballer {

--- a/rocket/src/footballer_repository.rs
+++ b/rocket/src/footballer_repository.rs
@@ -7,7 +7,7 @@ use crate::{
 
 pub trait FootballerRepository {
     fn create(&self, p_footballer: &NewFootballer) -> Result<Footballer, Error>;
-    fn find_by_position(&self, p_position: &String) -> Result<Vec<Footballer>, Error>;
+    fn find_by_position(&self, p_position: &str) -> Result<Vec<Footballer>, Error>;
     fn find_by_id(&self, p_id: i64) -> Result<Footballer, Error>;
     fn find_all(&self) -> Result<Vec<Footballer>, Error>;
     fn delete_by_id(&self, p_id: i64) -> Result<bool, Error>;
@@ -22,7 +22,7 @@ impl FootballerRepository
             .get_result::<Footballer>(self)
     }
 
-    fn find_by_position(self: &Self, p_position: &String) -> Result<Vec<Footballer>, Error> {
+    fn find_by_position(self: &Self, p_position: &str) -> Result<Vec<Footballer>, Error> {
         footballer
             .filter(position.eq(p_position))
             .load::<Footballer>(self)

--- a/rocket/src/footballer_repository.rs
+++ b/rocket/src/footballer_repository.rs
@@ -1,8 +1,9 @@
-use diesel::prelude::*;
-use diesel::result::Error;
+use diesel::{prelude::*, result::Error};
 
-use crate::footballer::{Footballer, NewFootballer};
-use crate::schema::footballer::dsl::*;
+use crate::{
+    footballer::{Footballer, NewFootballer},
+    schema::footballer::dsl::*,
+};
 
 pub trait FootballerRepository {
     fn create(&self, p_footballer: &NewFootballer) -> Result<Footballer, Error>;

--- a/rocket/src/main.rs
+++ b/rocket/src/main.rs
@@ -4,18 +4,14 @@
 extern crate diesel;
 #[macro_use]
 extern crate diesel_migrations;
-#[macro_use]
-extern crate log;
-#[macro_use]
-extern crate rocket;
-extern crate rocket_contrib;
 
 use std::collections::HashMap;
 
+use log::{error, info};
 use rocket::{
     config::{Config, Environment, Limits, Value},
     fairing::AdHoc,
-    Rocket,
+    routes, Rocket,
 };
 use rocket_contrib::database;
 

--- a/rocket/src/main.rs
+++ b/rocket/src/main.rs
@@ -12,11 +12,11 @@ extern crate rocket_contrib;
 
 use std::collections::HashMap;
 
-use rocket::config::Environment;
-use rocket::config::Value;
-use rocket::config::{Config, Limits};
-use rocket::fairing::AdHoc;
-use rocket::Rocket;
+use rocket::{
+    config::{Config, Environment, Limits, Value},
+    fairing::AdHoc,
+    Rocket,
+};
 use rocket_contrib::database;
 
 pub mod api;

--- a/rocket/src/main.rs
+++ b/rocket/src/main.rs
@@ -47,9 +47,8 @@ fn main() {
 
 fn run() -> anyhow::Result<()> {
     dotenv::dotenv().ok();
-    match std::env::var("RUST_LOG") {
-        Err(_) => std::env::set_var("RUST_LOG", "warn"),
-        _ => {}
+    if std::env::var("RUST_LOG").is_err() {
+        std::env::set_var("RUST_LOG", "warn")
     };
 
     env_logger::builder().init();


### PR DESCRIPTION
* merged imports (via the added `rustfmt.toml`) is a stylistic choice that I personally like and that seems quite popular in the community
* `extern crate` is no longer needed in the 2018 edition. Macros can now be imported individually (which I did with the `info` and `error` macros from `log` and the `get`/`post`/`delete` macros from `rocket`).
    I couldn't find the right macros to import to make the diesel stuff work properly so I kept the `#[macro_use] extern crate` statements for these...
* To use the `?` operator, it's common to make a main function as I did and move everything else in a second function.
    It's also possible (since [the 2018 edition](https://doc.rust-lang.org/edition-guide/rust-2018/error-handling-and-panics/question-mark-in-main-and-tests.html)) to have `main` return a `Result`, but that just prints any returned errors.
    We want to `error`-log them, so I think that approach is still the best one.
* To allow the `run` function to return both rocket's `LaunchError` and the custom error message (when `DATABASE_URL` is not set), I added `anyhow`, a library that offers a catch-all error type that's helpful when you want to handle all errors the same way (which is the case here).
* and lastly, if you don't know it yet, there's the linter [clippy](https://github.com/rust-lang/rust-clippy) which mostly gives good suggestions. It also complains about the `1 * 1024 * 1024` (because the `1 *` doesn't do anything), but I left that in because that place looked intentional :)